### PR TITLE
Fix and consistency for hex encoding.

### DIFF
--- a/src/node_murmurhash3.cc
+++ b/src/node_murmurhash3.cc
@@ -8,6 +8,7 @@
 #include <node.h>
 #include <iostream>
 #include <sstream>
+#include <iomanip>
 #include "MurmurHash3.h"
 
 #define REQ_ARG_COUNT_AND_TYPE(I, TYPE) \
@@ -116,7 +117,7 @@ Handle<Value> murmur32_sync(const Arguments& args) {
 
     if (isHexMode) {
         std::stringstream ss;
-        ss << std::hex << out;
+        ss << std::hex << std::setfill('0') << std::setw(8) << out;
         return scope.Close(String::New((ss.str()).c_str()));
     } else {
         return scope.Close(Integer::New(out));
@@ -138,8 +139,9 @@ Handle<Value> murmur128_sync(const Arguments& args) {
 
     if (isHexMode) {
         std::stringstream ss;
+        ss << std::hex << std::setfill('0');
         for (int i = 0; i < 4; i++) {
-            ss << std::hex << out[i];
+            ss << std::setw(8) << out[i];
         }
         return scope.Close(String::New((ss.str()).c_str()));
     } else {
@@ -170,7 +172,7 @@ void Work_After_murmur32(uv_work_t* req) {
     if (baton->isHexMode) {
         Local < Value > tmp = Integer::New(baton->result[0]);
         std::stringstream ss;
-        ss << std::hex << tmp->Uint32Value();
+        ss << std::hex << std::setfill('0') << std::setw(8) << tmp->Uint32Value();
         res[1] = String::New((ss.str()).c_str());
     } else {
         res[1] = Integer::NewFromUnsigned(baton->result[0]);
@@ -205,8 +207,9 @@ void Work_After_murmur128(uv_work_t *req) {
 
     if (baton->isHexMode) {
         std::stringstream ss;
+        ss << std::hex << std::setfill('0');
         for (int i = 0; i < 4; i++) {
-            ss << std::hex << result[i];
+            ss << std::setw(8) << result[i];
         }
         res[1] = String::New((ss.str()).c_str());
     } else {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,14 @@
 var mmh = mmh3 = require('./lib/murmurhash3');
-var testData = [["Hello", 0x12da77c8, [0x2360ae46, 0x5e6336c6, 0xad45b3f4, 0xad45b3f4]], ["Hello1", 0x6357e0a6, [0x8eb0cf41, 0x641b2401, 0xbc4c0dfc, 0xbc4c0dfc]], ["Hello2", 0xe5ce223e, [0xd3bcfc45, 0x66782162, 0x4beab2d1, 0x4beab2d1]]];
+var testData = [["Hello", 0x12da77c8, [0x2360ae46, 0x5e6336c6, 0xad45b3f4, 0xad45b3f4]], ["Hello1", 0x6357e0a6, [0x8eb0cf41, 0x641b2401, 0xbc4c0dfc, 0xbc4c0dfc]], ["Hello2", 0xe5ce223e, [0xd3bcfc45, 0x66782162, 0x4beab2d1, 0x4beab2d1]], ["2", 0x0129e217, [0x9dd4f4e7, 0x3df769b3, 0x3df769b3, 0x3df769b3]], ["88", 0x7a0040a5, [0x28979fa9, 0x0b1b1a58, 0x0b1b1a58, 0x0b1b1a58]]];
+
+function zeroFill(number, width) {
+  width -= number.toString().length;
+  if ( width > 0 )
+  {
+    return new Array( width + (/\./.test( number ) ? 2 : 1) ).join( '0' ) + number;
+  }
+  return number + ""; // always return a string
+}
 
 exports.setUp = function(cb) {
   cb();
@@ -14,7 +23,7 @@ for(var i = 0; i < testData.length; i++) {
   };
   exports["testAsyncInterface32Hex_" + i] = function(test) {
     mmh3.murmur32Hex(val[0], function(err, res) {
-      test.equal(res, val[1].toString(16), 'murmur32Hex-' + i);
+      test.equal(res, zeroFill(val[1].toString(16), 8), 'murmur32Hex-' + i);
       test.done();
     });
   };
@@ -28,7 +37,7 @@ for(var i = 0; i < testData.length; i++) {
     mmh3.murmur128Hex(val[0], function(err, res) {
       var expect = '';
       for(var j = 0; j < 4; j++) {
-        expect += val[2][j].toString(16);
+        expect += zeroFill(val[2][j].toString(16), 8);
       }
       test.equal(res, expect, 'murmur128Hex-' + i);
       test.done();
@@ -39,13 +48,13 @@ for(var i = 0; i < testData.length; i++) {
       res = mmh3.murmur32Sync(val[0]);
       test.equal(res, val[1], 'murmur32-' + i);
       res = mmh3.murmur32HexSync(val[0]);
-      test.equal(res, val[1].toString(16), 'murmur32Hex-' + i);
+      test.equal(res, zeroFill(val[1].toString(16), 8), 'murmur32Hex-' + i);
       res = mmh3.murmur128Sync(val[0]);
       test.deepEqual(res, val[2], 'murmur128-' + i);
       res = mmh3.murmur128HexSync(val[0]);
       var expect = '';
       for(var j = 0; j < 4; j++) {
-        expect += val[2][j].toString(16);
+        expect += zeroFill(val[2][j].toString(16), 8);
       }
       test.equal(res, expect, 'murmur128Hex-' + i);
       test.done();   


### PR DESCRIPTION
This is a crucial fix for 128Hex as those methods can return an
inccorect number.  For consistency this is applied to all hex returns so
that there is a leading 0 as well.  This allows for a consistent length
field that is easily used as a key.
