### PR TITLE
manually calling node-gyp is not needed anymore with recent npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "keywords": ["hash", "murmurhash"],
   "author": "Hideaki Ohno <hide.o.j55@gmail.com>",
   "dependencies": {
-    "node-gyp": ""
   },
   "devDependencies": {
     "nodeunit": ""
@@ -16,7 +15,6 @@
     "node": ">=0.6.x"
   },
   "scripts": {
-    "install": "node-gyp rebuild",
     "test": "nodeunit --reporter tap test.js"
   }
 }


### PR DESCRIPTION
npm will run node-gyp when it finds a binding.gyp in the module, so manually calling node-gyp is not needed anymore.
