### PR TITLE
update Nan version to remove deprecated warnnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmurhash3",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Node binding of MurmurHash3",
   "repository": "https://github.com/hideo55/node-murmurhash3",
   "bugs": {
@@ -14,10 +14,10 @@
   ],
   "author": "Hideaki Ohno <hide.o.j55@gmail.com>",
   "dependencies": {
-    "nan": "2.3.5"
+    "nan": "2.4.0"
   },
   "devDependencies": {
-    "mocha": "~2.0.0"
+    "mocha": "3.2.0"
   },
   "main": "./lib/murmurhash3.js",
   "engines": {

--- a/src/node_murmurhash3.cc
+++ b/src/node_murmurhash3.cc
@@ -175,7 +175,7 @@ NAN_METHOD(murmur32_async) {
     REQ_FUN_ARG(3, cb);
 
     std::string key = *String::Utf8Value(info[0]->ToString());
-    uint32_t seed = info[1]->ToUint32()->Value();
+    uint32_t seed = Nan::To<uint32_t>(info[1]).FromJust();
 
     Nan::Callback *callback = new Nan::Callback(cb);
     bool hexMode = info[2]->ToBoolean()->Value();
@@ -196,7 +196,7 @@ NAN_METHOD(murmur128_async) {
     REQ_FUN_ARG(3, cb);
 
     std::string key = *String::Utf8Value(info[0]->ToString());
-    uint32_t seed = info[1]->ToUint32()->Value();
+    uint32_t seed = Nan::To<uint32_t>(info[1]).FromJust();
 
     Nan::Callback *callback = new Nan::Callback(cb);
     bool hexMode = info[2]->ToBoolean()->Value();
@@ -217,7 +217,7 @@ NAN_METHOD(murmur32_sync) {
     REQ_BOOL_ARG(2);
 
     String::Utf8Value key(info[0]->ToString());
-    uint32_t seed = info[1]->ToUint32()->Value();
+    uint32_t seed = Nan::To<uint32_t>(info[1]).FromJust();
     bool hexMode = info[2]->ToBoolean()->Value();
 
     MurmurHash3_x86_32(reinterpret_cast<const char *>(*key), (int) key.length(), seed, &out);
@@ -240,7 +240,7 @@ NAN_METHOD(murmur128_sync) {
     REQ_BOOL_ARG(2);
 
     String::Utf8Value key(info[0]->ToString());
-    uint32_t seed = info[1]->ToUint32()->Value();
+    uint32_t seed = Nan::To<uint32_t>(info[1]).FromJust();
     bool hexMode = info[2]->ToBoolean()->Value();
 
     MurmurHash3_x86_128(reinterpret_cast<const char *>(*key), (int) key.length(), seed, &out);


### PR DESCRIPTION
update Nan version to 2.4.0, replace deprecated ToUint method;
update mocha to 3.2.0;

If execute `npm install` under elder version, it will show warnnings of deprecated ToUnit method.

update Nan to 2.4.0 and change the ToUnit usage will fix it.

upate mocha for some other deprecated warnings.